### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,5 +1,7 @@
 ---
 name: Code Quality
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/bryanculbertson/python-template/security/code-scanning/2](https://github.com/bryanculbertson/python-template/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the jobs to function correctly. For this workflow:
- The `pre-commit` job likely only requires `contents: read` permissions.
- The `test` job also likely only requires `contents: read` permissions, as it interacts with Codecov and caches dependencies but does not modify repository contents.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. Adding it at the root level is more concise and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
